### PR TITLE
Add code to create dataset splits (training/validation/test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 # sublime text configuration files
 *.sublime-project
 *.sublime-workspace
+
+# training/validation/test split datasets
+data/split/

--- a/create_datasets.py
+++ b/create_datasets.py
@@ -1,0 +1,380 @@
+from data_manager import DATA_SPLIT_PATH, SPLIT_DATASET_FORMAT
+from data_manager import get_bible_versions, get_shared_bible_verses, get_bible_books
+from data_manager import VerseIdentifier
+
+from time import time
+import random, shutil, re
+from collections import defaultdict
+from typing import Callable
+
+def prompt_boolean(prompt: str, default: bool) -> bool:
+    """
+    Prompts the user for a yes/no answer, given a default value.
+    It keeps asking until a valid answer is provided. Valid answers include:
+    - {blank}  -> returns default
+    - {[yY].*} -> returns True
+    - {[nN].*} -> returns false
+
+    Arguments:
+        prompt {str} -- the prompt to prompt
+        default {bool} -- the default value
+
+    Example output:
+        Do you want to shuffle the dataset verses? [Y/n] apples
+
+        Invalid response 'apples', must enter yes or no:
+        Do you want to shuffle the dataset verses? [Y/n]
+    """
+    y = 'Y' if default else 'y'
+    n = 'n' if default else 'N'
+    full_prompt = f'{prompt} [{y}/{n}] '
+
+    while True:
+        response = input(full_prompt).lower().strip()
+
+        if not response:
+            # no response was given, use default
+            return default
+
+        if response[0] == 'y':
+            return True
+        elif response[0] == 'n':
+            return False
+
+        print(f"\nInvalid response '{response}', must enter yes or no:")
+
+def prompt_int(prompt: str, default: int, min_value: int, max_value: int) -> int:
+    """
+    Similar to prompt boolean, but for an integer value.
+
+    Arguments:
+        prompt {str} -- prompt to prompt
+        default {int} -- default integer value
+        min_value {int} -- minimum allowed value
+        max_value {int} -- maximum allowed value
+
+    Returns:
+        int -- value chosen
+
+    Example output:
+        What percentage of the data ...? [0-100,default=70] 150
+
+        Response must be between 0 to 100
+        What percentage of the data ...? [0-100,default=70]
+    """
+    full_prompt = f'{prompt} [{min_value}-{max_value},default={default}] '
+
+    while True:
+        try:
+            response = input(full_prompt).strip()
+
+            if not response:
+                return default
+
+            response_int = int(response)
+
+            if response_int < min_value or response_int > max_value:
+                print(f'\nResponse must be between {min_value} to {max_value}')
+            else:
+                return response_int
+
+        except Exception:
+            print(f"\nInvalid response '{response}', must enter an integer:")
+
+def time_function(message: str, function: Callable[[], object or None], verbose: bool, num_characters: int = 50) -> object or None:
+    """
+    Pretty simple/sweet helper function that times and prints the
+    execution time of another function. Returns whatever the other
+    function returned.
+
+    Arguments:
+        message {str} -- description of what the function is doing
+        function: {Callable[[], object or None]} -- the function to call and time
+        verbose {bool} -- whether or not to print anything
+
+    Keyword Arguments:
+        num_characters {int} -- number of characters to pad the message to (for aligning) (default: {50})
+
+    Returns:
+        object or None -- whatever the function argument returned
+
+    Example output:
+        Finding shared verses between 7 versions...        done in 0.961 seconds
+    """
+    verbose and print(f'{message:{num_characters}}', end = ' ', flush = True)
+
+    start_time = time()
+    response = function()
+    end_time = time()
+
+    verbose and print(f'done in {end_time - start_time:.3f} seconds')
+
+    return response
+
+def get_test_bible_book_ids() -> {int}:
+    """
+    Pretty simple function that gets the id #s of the test bible books.
+    Some bible books are allocated as 'test' books, this creates a list of their IDs.
+
+    Returns:
+        {1, 5, 13, 15, 16, 18, 19, 21, 25, 30, 36, 37, 42, 43, 45, 50, 51, 52, 53, 55, 57, 60, 62, 66}
+    """
+    return {book_id for (book_id, book) in get_bible_books().items() if book['dataset'] == 'test' }
+
+def filter_test_verses(verses: {VerseIdentifier: [str]}) -> ({VerseIdentifier: [str], VerseIdentifier: [str]}):
+    """
+    Given a dictionary of verses (i.e., the return type of get_shared_bible_verses),
+    this splits it up into two dictionaries, one of the non-test verses, and another
+    of the test verses. The test versions are determined by belonging to a test book,
+    see get_test_bible_book_ids.
+
+    Example return:
+        (
+            {
+                VerseIdentifier(book=2, chaper=1, verse=1): [
+                    'Now these are the names of the sons of Israel, who came into Egypt (every man and his household came with Jacob):',
+                    'Now these are the names of the sons of Israel who came into Egypt; every man and his family came with Jacob.',
+                    ...
+                ],
+                ...
+            },
+            {
+                VerseIdentifier(book=1, chaper=1, verse=1): [
+                    'In the beginning God created the heavens and the earth.',
+                    'At the first God made the heaven and the earth.',
+                    ...
+                ],
+                ...
+            }
+        )
+    """
+    test_book_ids = get_test_bible_book_ids()
+
+    return dict(filter(lambda kv: kv[0].book not in test_book_ids, verses.items())), \
+           dict(filter(lambda kv: kv[0].book in     test_book_ids, verses.items()))
+
+def filter_validation_verses(verses: {VerseIdentifier: [str]}, training_fraction: float) -> ({VerseIdentifier: [str], VerseIdentifier: [str]}):
+    """
+    Same thing as filter_test_verses, but instead of splitting by book,
+    it splits by a random sample of data points based on the training
+    fraction. This is used to split the non-test verses into a training
+    and a validation set.
+    """
+    num_training_verses = int(len(verses) * training_fraction)
+    training_verse_ids = set(random.sample(list(verses), k = num_training_verses))
+
+    return dict(filter(lambda kv: kv[0] in     training_verse_ids, verses.items())), \
+           dict(filter(lambda kv: kv[0] not in training_verse_ids, verses.items()))
+
+def zip_verses(bible_versions: [dict], verses: {VerseIdentifier: [str]}, shuffle: bool) -> {str: [str]}:
+    """
+    Converts the verse-index based dictionary to a bible-version based dictionary.
+    In other words, changed from this:
+        {
+            VerseIdentifier(...): [
+                <bible version 1 translation>,
+                <bible version 2 translation>,
+                <bible version 3 translation>,
+                ...
+            ],
+            VerseIdentifier(...): [
+                <bible version 1 translation>,
+                ...
+            ],
+            ...
+        }
+    To this:
+        {
+            <bible 1>: [
+                <verse 1 translation>,
+                <verse 2 translation>,
+                ...
+            ],
+            <bible 2>: [
+                <verse 1 translation>,
+                <verse 2 translation>,
+            ...
+            ],
+            ...
+        }
+
+    And this function can optionally shuffle all the verses as well.
+
+    Example return:
+        {
+            't_asv': [
+                'In the beginning God created the heavens and the earth.',
+                'And the earth was waste and void; and darkness was ...',
+                ...
+            ],
+            't_bbe': [
+                'At the first God made the heaven and the earth.',
+                'And the earth was waste and without form; and it was dark ...',
+                ...
+            ],
+            't_dby': [
+                'In the beginning God created the heavens and the earth.',
+                'And the earth was waste and empty, and darkness...',
+                ...
+            ]
+        }
+    """
+    table_names = [version['table'] for version in bible_versions]
+
+    split_verses = defaultdict(list)
+
+    verse_values = list(verses.values())
+    if shuffle:
+        random.shuffle(verse_values)
+
+    for verse_texts in verse_values:
+        for (table_name, text) in zip(table_names, verse_texts):
+            split_verses[table_name].append(text)
+
+    return split_verses
+
+def zip_split_verses(bible_versions: [dict], split_verses: {str: {VerseIdentifier: [str]}}, shuffle: bool) -> {str: {str: [str]}}:
+    """
+    See zip_verses above.
+
+    Returns:
+        {
+            'training': <zip_verses output on training data>,
+            'validation': <zip_verses output on validation data>,
+            'test': <zip_verses output on test data>
+        }
+    """
+    return { dataset: zip_verses(bible_versions, verses, shuffle) for (dataset, verses) in split_verses.items() }
+
+def write_zipped_verses(zipped_verses: {str: {str: [str]}}):
+    """
+    Writes the contents of a  zipped verses object (zip_split_verses return type)
+    to many different files under the new data/split directory (more generally, the
+    DATA_SPLIT_PATH directory), deleting the previous directory contents. This way
+    there are no artifacts from a previous execution.
+    """
+    shutil.rmtree(DATA_SPLIT_PATH, ignore_errors = True)
+    DATA_SPLIT_PATH.mkdir()
+
+    for (dataset, verse_versions) in zipped_verses.items():
+        for (table, verses) in verse_versions.items():
+            path = DATA_SPLIT_PATH / SPLIT_DATASET_FORMAT.format(dataset = dataset, table = table)
+
+            with open(path, 'w') as file:
+                file.write('\n'.join(verses))
+
+def create_datasets(bible_versions: [dict], training_fraction: float, shuffle: bool = True, write_files: bool = False, verbose: bool = True) -> {str: {str: [str]}}:
+    """
+    Creates dataset splits from specific bible versions, and returns the split.
+    This should take ~1 second or so to execute. If this is too slow for you,
+    or if you prefer not to recreate the datasets every time, consider writing
+    the results to files, and then reading from those files using the read_datasets
+    function.
+
+    By default prints execution status and details, but that can be disabled with
+    through the verbose argument.
+
+    Arguments:
+        bible_versions {[dict]} -- list of bible version objects, as returned by get_bible_versions
+        training_fraction {float} -- fraction of non-test data to be allocated to training
+
+    Keyword Arguments:
+        shuffle {bool} -- [whether to shuffle the verses] (default: {True})
+        write_files {bool} -- [whether to write to files] (default: {False})
+        verbose {bool} -- [whether to print status and details] (default: {True})
+
+    Example return:
+        {
+            'training': {
+                't_asv': [
+                    'Then said Achish unto his servants, Lo, ye see the man is mad; wherefore then have ye brought him to me?',
+                    'These things did Benaiah the son of Jehoiada, and had a name among the three mighty men.',
+                    ...
+                ],
+                't_bbe': [
+                    'Then Achish said to his servants, Look! the man is clearly off his head; why have you let him come before me?',
+                    'These were the acts of Benaiah, the son of Jehoiada, who had a great name among the thirty men of war.',
+                    ...
+                ],
+                ...
+            },
+            'validation': {
+                't_asv': [
+                    'These are they who make separations, sensual, having not the Spirit.',
+                    'And Abimelech dwelt at Arumah: and Zebul drove out Gaal and his brethren, that they should not dwell in Shechem.',
+                    ...
+                ],
+                ...
+            },
+            'test': {
+                ...
+            }
+        }
+    """
+    shared_verses = time_function(f'Finding shared verses between {len(bible_versions)} versions...',
+        lambda: get_shared_bible_verses(bible_versions), verbose)
+
+    if len(shared_verses) == 0:
+        print(f'WARNING: There were no shared verses between the given versions.')
+        return { 'training': [], 'validation': [], 'test': [] }
+
+    training_verses, test_verses = time_function('Separate test verses...',
+        lambda: filter_test_verses(shared_verses), verbose)
+
+    training_verses, validation_verses = time_function('Separate validation verses...',
+        lambda: filter_validation_verses(training_verses, training_fraction), verbose)
+
+    split_verses = { 'training': training_verses, 'validation': validation_verses, 'test': test_verses }
+
+    zipped_verses = time_function(f'Zip together verses (shuffle = {shuffle})...',
+        lambda: zip_split_verses(bible_versions, split_verses, shuffle), verbose)
+
+    if write_files:
+        time_function(f'Store datasets to files...',
+            lambda: write_zipped_verses(zipped_verses), verbose)
+
+    verbose and print(f'\n# Training Verses:   {len(training_verses):7,d} ({len(training_verses) / len(shared_verses) * 100:.0f}%)\n# Validation Verses: {len(validation_verses):7,d} ({len(validation_verses) / len(shared_verses) * 100:.0f}%)\n# Test Verses:       {len(test_verses):7,d} ({len(test_verses) / len(shared_verses) * 100:.0f}%)')
+
+    return zipped_verses
+
+def load_datasets() ->  {str: {str: [str]}}:
+    """
+    Loads datasets already created through create_datasets. Takes on the order
+    of tenths of seconds. Returns the same object that create_datasets returned.
+    """
+    zipped_verses = defaultdict(lambda: defaultdict(list))
+
+    for path in DATA_SPLIT_PATH.glob('*.txt'):
+        table, dataset = re.match(r'^(.+)_(validation|training|test)$', path.stem).groups()
+
+        with open(path, 'r') as file:
+            zipped_verses[dataset][table] = file.read().splitlines()
+
+    return zipped_verses
+
+def _prompt_create_datasets():
+    if DATA_SPLIT_PATH.exists() and not prompt_boolean('Are you sure you want to overwrite your existing dataset split directory?', default = False):
+        print('Aborting.')
+        exit(0)
+
+    training_fraction = prompt_int(
+        'What percentage of the data should be training data (versus validation data)?',
+        default = 70,
+        min_value = 0,
+        max_value = 100) / 100
+
+    shuffle = prompt_boolean('Do you want to shuffle the dataset verses?', default = True)
+
+    print()
+
+    create_datasets(
+        bible_versions = get_bible_versions()[:7],
+        training_fraction = training_fraction,
+        shuffle = shuffle,
+        write_files = True,
+        verbose = True
+    )
+
+
+if __name__ == '__main__':
+    _prompt_create_datasets()

--- a/data_manager.py
+++ b/data_manager.py
@@ -1,18 +1,18 @@
 # Standard libraries
 import csv
 from pathlib import Path
-
-# Additional libraries (pip install ...)
-import texttable
+from collections import defaultdict, namedtuple
 
 # Paths
 PROJECT_DIRECTORY = Path(__file__).parent
 DATA_PATH = PROJECT_DIRECTORY /  'data'
+DATA_SPLIT_PATH = DATA_PATH / 'split'
 KEY_GENRE_ENGLISH_PATH = DATA_PATH / 'key_genre_english.csv'
 KEY_ENGLISH_PATH = DATA_PATH / 'key_english.csv'
 TABLE_KEY_PATH = DATA_PATH / 't_key.csv'
 TABLE_DIRECTORY = DATA_PATH
 TABLE_NAME_FORMAT = '{table}.csv'
+SPLIT_DATASET_FORMAT = '{table}_{dataset}.txt'
 
 # CSV header names
 BOOK_KEY = 'b'
@@ -23,6 +23,9 @@ TESTAMENT_KEY = 't'
 GENRE_KEY = 'g'
 NAME_KEY = 'n'
 DATASET_KEY = 'dataset'
+ID_KEY = 'id'
+
+VerseIdentifier = namedtuple('VerseIdentifier', ['book', 'chaper', 'verse'])
 
 # Other constants
 TESTAMENT_NAMES = { 'OT': 'Old Testament', 'NT': 'New Testament' }
@@ -134,6 +137,71 @@ def get_bible_books() -> {int: dict}:
             } for book in reader
         }
 
+def get_bible_verses(bible_version: dict) -> {VerseIdentifier: str}:
+    """
+    This returns a dictionary where each key is the verse identifier (namedtuple, see below example),
+    and each value is the verse text, for a given bible version.
+
+    Arguments:
+        bible_version {dict} -- the bible version object, as returned by get_bible_versions
+
+    Example return:
+        {
+            VerseIdentifier(book=1, chaper=1, verse=1): 'In the beginning God created the heavens and the earth.',
+            VerseIdentifier(book=1, chaper=1, verse=2): 'And the earth was waste and void; and darkness was upon the face of the deep: and the Spirit of God moved upon the face of the waters.',
+            ...
+            VerseIdentifier(book=66, chaper=22, verse=21): 'The grace of the Lord Jesus be with the saints. Amen.'
+        }
+    """
+    table_path = TABLE_DIRECTORY / TABLE_NAME_FORMAT.format(table = bible_version['table'])
+
+    with open(table_path, 'r', encoding='latin-1') as csvfile:
+        reader = csv.reader(csvfile)
+
+        headers = next(reader)
+        book_index = headers.index(BOOK_KEY)
+        chaper_index = headers.index(CHAPTER_KEY)
+        verse_index = headers.index(VERSE_KEY)
+        text_index = headers.index(TEXT_KEY)
+
+        return { VerseIdentifier(int(verse[book_index]), int(verse[chaper_index]), int(verse[verse_index])): verse[text_index] for verse in reader }
+
+def get_shared_bible_verses(bible_versions: [dict]) -> {VerseIdentifier: [str]}:
+    """
+    Returns the verses that are shared between all the bible versions in
+    the argument. The verses are returned as a dict where the key is the verse
+    index, and the value is a list of the translations in the same order as
+    the bible_versions argument.
+
+    Arguments:
+        bible_versions {[dict]} -- list of bible version objects, as returned by get_bible_versions
+
+    Example return:
+        {
+            VerseIdentifier(book=1, chaper=1, verse=1): [
+                'In the beginning God created the heavens and the earth.',
+                'At the first God made the heaven and the earth.',
+                ...
+            ],
+            VerseIdentifier(book=1, chaper=1, verse=2): [
+                'And the earth was waste and void; and darkness was upon the face of the deep: and the Spirit of God moved upon the face of the waters.',
+                'And the earth was waste and without form; and it was dark on the face of the deep: and the Spirit of God was moving on the face of the waters.',
+                ...
+            ],
+            ...
+        }
+    """
+    all_verses = defaultdict(list)
+
+    for version in bible_versions:
+        for (verse_id, verse) in get_bible_verses(version).items():
+            all_verses[verse_id].append(verse)
+
+    return dict(filter(
+        lambda kv: len(kv[1]) == len(bible_versions),
+        all_verses.items()
+    ))
+
 def get_books_contained_by_version(bible_version: dict) -> [int]:
     """
     Some versions might be missing books (once we start web scraping).
@@ -175,123 +243,3 @@ def get_versions_missing_books(bible_versions: [dict]) -> {int: [int]}:
 
     return { version['id']: sorted(all_books - set(get_books_contained_by_version(version))) for version in bible_versions }
 
-def _print_table(title: str, headers: [str], rows: [int or str], align: [str] or None = None):
-    """
-    Helper function to print an ASCII table
-
-    Arguments:
-        title {str} -- table title
-        headers {[str]} -- list of table headers
-        rows {[int or str]} -- list of table rows
-
-    Keyword Arguments:
-        align: {[str] or None} -- how to align the columns (default: {None})
-    """
-    table = texttable.Texttable()
-    table.header(headers)
-    table.add_rows(rows, header = False)
-    align and table.set_cols_align(align)
-
-    print(title)
-    print(table.draw())
-
-def _print_version_table():
-    bible_versions = get_bible_versions()
-    missing_books = get_versions_missing_books(bible_versions)
-
-    rows = [(
-        version['id'],
-        version['abbreviation'],
-        version['version'],
-        'contains all books' if len(missing_books[version['id']]) == 0 else ', '.join((str(book_id) for book_id in missing_books[version['id']]))
-    ) for version in bible_versions]
-
-    _print_table(
-        title = "Bible Version Table",
-        headers = ['id', 'abbr', 'version', 'missing books'],
-        rows = rows
-    )
-
-def _print_genre_table():
-    genres = get_bible_book_genres()
-    book_genres = [book['genre_id'] for book in get_bible_books().values()]
-
-    rows = [(
-        genre_id,
-        genre,
-        book_genres.count(genre_id)
-    ) for (genre_id, genre) in sorted(genres.items())]
-
-    _print_table(
-        title = "Bible Genre Table",
-        headers = ['id', 'name', '# books'],
-        rows = rows
-    )
-
-def _print_testament_table():
-    books = get_bible_books()
-    testament_labels = [book['testament'] for book in books.values()]
-
-    rows = [(
-        testament_label,
-        TESTAMENT_NAMES[testament_label],
-        testament_labels.count(testament_label)
-    ) for testament_label in sorted(set(testament_labels))]
-
-    _print_table(
-        title = "Bible Testament Table",
-        headers = ['label', 'name', '# books'],
-        rows = rows
-    )
-
-def _get_genre_dataset_split(genre_id: int, dataset: str) -> int:
-    return len(list(filter(lambda book: book['genre_id'] == genre_id and book['dataset'] == dataset, get_bible_books().values())))
-
-def _print_genre_data_split_table():
-    genres = get_bible_book_genres()
-
-    rows = [(
-        genre,
-        f"{_get_genre_dataset_split(genre_id, 'train')} / {_get_genre_dataset_split(genre_id, 'test')}"
-    ) for (genre_id, genre) in sorted(genres.items())]
-
-    _print_table(
-        title = "Bible Genre Data Split Table",
-        headers = ['genre', 'train / test split'],
-        rows = rows,
-        align = ['l', 'c']
-    )
-
-def _get_testament_dataset_split(testament: str, dataset: str) -> int:
-    return len(list(filter(lambda book: book['testament'] == testament and book['dataset'] == dataset, get_bible_books().values())))
-
-def _print_testament_data_split_table():
-    books = get_bible_books()
-    testament_labels = [book['testament'] for book in books.values()]
-
-    rows = [(
-        TESTAMENT_NAMES[testament_label],
-        f"{_get_testament_dataset_split(testament_label, 'train')} / {_get_testament_dataset_split(testament_label, 'test')}"
-    ) for testament_label in sorted(set(testament_labels))]
-
-    _print_table(
-        title = "Bible Testament Data Split Table",
-        headers = ['testament', 'train / test split'],
-        rows = rows,
-        align = ['l', 'c']
-    )
-
-def _print_summary_tables():
-    _print_version_table()
-    print()
-    _print_genre_table()
-    print()
-    _print_testament_table()
-    print()
-    _print_genre_data_split_table()
-    print()
-    _print_testament_data_split_table()
-    print()
-
-if __name__ == '__main__':
-    _print_summary_tables()

--- a/summarize_data.py
+++ b/summarize_data.py
@@ -1,0 +1,126 @@
+from data_manager import get_bible_versions, get_versions_missing_books, get_bible_book_genres, get_bible_books
+from data_manager import TESTAMENT_NAMES
+
+# Additional libraries (pip install ...)
+import texttable
+
+def _print_table(title: str, headers: [str], rows: [int or str], align: [str] or None = None):
+    """
+    Helper function to print an ASCII table
+
+    Arguments:
+        title {str} -- table title
+        headers {[str]} -- list of table headers
+        rows {[int or str]} -- list of table rows
+
+    Keyword Arguments:
+        align: {[str] or None} -- how to align the columns (default: {None})
+    """
+    table = texttable.Texttable()
+    table.header(headers)
+    table.add_rows(rows, header = False)
+    align and table.set_cols_align(align)
+
+    print(title)
+    print(table.draw())
+
+def _print_version_table():
+    bible_versions = get_bible_versions()
+    missing_books = get_versions_missing_books(bible_versions)
+
+    rows = [(
+        version['id'],
+        version['abbreviation'],
+        version['version'],
+        'contains all books' if len(missing_books[version['id']]) == 0 else ', '.join((str(book_id) for book_id in missing_books[version['id']]))
+    ) for version in bible_versions]
+
+    _print_table(
+        title = "Bible Version Table",
+        headers = ['id', 'abbr', 'version', 'missing books'],
+        rows = rows
+    )
+
+def _print_genre_table():
+    genres = get_bible_book_genres()
+    book_genres = [book['genre_id'] for book in get_bible_books().values()]
+
+    rows = [(
+        genre_id,
+        genre,
+        book_genres.count(genre_id)
+    ) for (genre_id, genre) in sorted(genres.items())]
+
+    _print_table(
+        title = "Bible Genre Table",
+        headers = ['id', 'name', '# books'],
+        rows = rows
+    )
+
+def _print_testament_table():
+    books = get_bible_books()
+    testament_labels = [book['testament'] for book in books.values()]
+
+    rows = [(
+        testament_label,
+        TESTAMENT_NAMES[testament_label],
+        testament_labels.count(testament_label)
+    ) for testament_label in sorted(set(testament_labels))]
+
+    _print_table(
+        title = "Bible Testament Table",
+        headers = ['label', 'name', '# books'],
+        rows = rows
+    )
+
+def _get_genre_dataset_split(genre_id: int, dataset: str) -> int:
+    return len(list(filter(lambda book: book['genre_id'] == genre_id and book['dataset'] == dataset, get_bible_books().values())))
+
+def _print_genre_data_split_table():
+    genres = get_bible_book_genres()
+
+    rows = [(
+        genre,
+        f"{_get_genre_dataset_split(genre_id, 'train')} / {_get_genre_dataset_split(genre_id, 'test')}"
+    ) for (genre_id, genre) in sorted(genres.items())]
+
+    _print_table(
+        title = "Bible Genre Data Split Table",
+        headers = ['genre', 'train / test split'],
+        rows = rows,
+        align = ['l', 'c']
+    )
+
+def _get_testament_dataset_split(testament: str, dataset: str) -> int:
+    return len(list(filter(lambda book: book['testament'] == testament and book['dataset'] == dataset, get_bible_books().values())))
+
+def _print_testament_data_split_table():
+    books = get_bible_books()
+    testament_labels = [book['testament'] for book in books.values()]
+
+    rows = [(
+        TESTAMENT_NAMES[testament_label],
+        f"{_get_testament_dataset_split(testament_label, 'train')} / {_get_testament_dataset_split(testament_label, 'test')}"
+    ) for testament_label in sorted(set(testament_labels))]
+
+    _print_table(
+        title = "Bible Testament Data Split Table",
+        headers = ['testament', 'train / test split'],
+        rows = rows,
+        align = ['l', 'c']
+    )
+
+def _print_summary_tables():
+    _print_version_table()
+    print()
+    _print_genre_table()
+    print()
+    _print_testament_table()
+    print()
+    _print_genre_data_split_table()
+    print()
+    _print_testament_data_split_table()
+    print()
+
+if __name__ == '__main__':
+    _print_summary_tables()


### PR DESCRIPTION
Refactor code to make it cleaner (split data_summary to data_manager and summarize_data).

Added a create_datasets file which contains functions to split the data into training/validation/test sets, or load the aforementioned sets from stored files under a new data/splits directory.

When called directly (i.e. python3 create_datasets.py) it walks you through the process, but it can also be called programmatically.

Here is sample output when calling it directly:
```
Are you sure you want to overwrite your existing dataset split directory? [y/N] y
What percentage of the data should be training data (versus validation data)? [0-100,default=70] 75
Do you want to shuffle the dataset verses? [Y/n] 

Finding shared verses between 7 versions...        done in 1.031 seconds
Separate test verses...                            done in 0.015 seconds
Separate validation verses...                      done in 0.021 seconds
Zip together verses (shuffle = True)...            done in 0.074 seconds
Store datasets to files...                         done in 0.061 seconds

# Training Verses:    14,465 (47%)
# Validation Verses:   4,822 (16%)
# Test Verses:        11,704 (38%)
```

Which created the following files:
```bash
ls data/split
t_asv_test.txt        t_bbe_training.txt    t_dby_validation.txt  t_wbt_test.txt        t_web_training.txt    t_ylt_validation.txt
t_asv_training.txt    t_bbe_validation.txt  t_kjv_test.txt        t_wbt_training.txt    t_web_validation.txt
t_asv_validation.txt  t_dby_test.txt        t_kjv_training.txt    t_wbt_validation.txt  t_ylt_test.txt
t_bbe_test.txt        t_dby_training.txt    t_kjv_validation.txt  t_web_test.txt        t_ylt_training.txt
```

Resolves #2 